### PR TITLE
Resolve spotify problems neatly

### DIFF
--- a/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
+++ b/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
@@ -3331,10 +3331,34 @@ body.foldercontentopened .base-2jDfDU {
     border-right: 1px solid var(--spotify-color);
     overflow: hidden;
 }
+.wrapper-3Hk9OB:empty ~ .powercord-spotify:hover {
+  height: 80px;
+}
+
+.wrapper-3Hk9OB:hover ~ .powercord-spotify{
+  left: 0px;
+  height: 150px;
+}
+
+.wrapper-3Hk9OB:after:hover ~ .powercord-spotify{
+  left: 0px;
+  height: 150px;
+}
+
+.avatarWrapper-1B9FTW:hover ~ .powercord-spotify{
+  left: 0px;
+  height: 150px;
+}
 
 .powercord-spotify:hover {
-    left: 0px;
-    height: 80px;
+  left: 0px;
+  height: 150px;
+}
+.panels-3wFtMD .wrapper-3Hk9OB .container-1zzFcN:after, .panels-3wFtMD .wrapper-3Hk9OB~.container-YkUktl .directionRow-2Iu2A9:after {
+  width: 242px
+}
+.panels-3wFtMD .wrapper-3Hk9OB~.container-YkUktl .directionRow-2Iu2A9:after {
+  display: none;
 }
 
 .spotify-buttons {

--- a/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
+++ b/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
@@ -3325,7 +3325,7 @@ body.foldercontentopened .base-2jDfDU {
     bottom: -12px;
     left: -150px;
     width: 200px !important;
-    height: 35px;
+    height: 50px;
     background-color: var(--background-secondary);
     border-top: 1px solid var(--spotify-color);
     border-right: 1px solid var(--spotify-color);
@@ -3334,12 +3334,12 @@ body.foldercontentopened .base-2jDfDU {
 
 .powercord-spotify:hover {
     left: 0px;
-    height: 60px;
+    height: 80px;
 }
 
 .spotify-buttons {
     position: absolute;
-    top: 30px !important;
+    top: 45px !important;
     left: 4px !important;
     margin: 0 0 !important;
     transition: 0.2s;

--- a/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
+++ b/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
@@ -3317,41 +3317,63 @@ body.foldercontentopened .base-2jDfDU {
 }
 
 .powercord-spotify {
-    padding-top: 1rem;
+    transition-property: left, height;
+    transition-duration:  0.4s;
+    border-top-right-radius: 25px;
+    position: absolute;
+    z-index: 1;
+    bottom: -12px;
+    left: -150px;
+    width: 200px !important;
+    height: 35px;
+    background-color: var(--background-secondary);
+    border-top: 1px solid var(--spotify-color);
+    border-right: 1px solid var(--spotify-color);
+    overflow: hidden;
+}
+
+.powercord-spotify:hover {
+    left: 0px;
+    height: 60px;
 }
 
 .spotify-buttons {
-    margin: 0;
-    top: 50%;
-    left: 10rem;
-    position: relative;
+    position: absolute;
+    top: 30px !important;
+    left: 4px !important;
+    margin: 0 0 !important;
+    transition: 0.2s;
+    width: 100%;
 }
 
 .powercord-spotify>.container-YkUktl>.avatarWrapper-1B9FTW {
     position: absolute;
-    top: 91.7%;
-    left: 0;
-    right: 83%;
+    top: 10px;
+    left: 155px;
+    right: 10px;
+    margin: 0 auto !important;
+    transition: 0.2s
+
+}
+.powercord-spotify:hover>.container-YkUktl>.avatarWrapper-1B9FTW {
+    position: absolute;
+    top: 10px;
+    left: 155px;
+    right: 10px;
     margin: 0 auto !important;
     transition: 0.2s
 }
-
-.powercord-spotify:hover>.container-YkUktl>.avatarWrapper-1B9FTW {
-    top: 88.2%
-}
-
 .powercord-spotify>.container-YkUktl>.nameTag-sc-gpq {
     position: absolute;
-    top: 90.5%;
-    left: 0;
-    right: 85.5%;
-    margin: 0 auto !important;
+    top: 4px;
+    left: 4px;
+    margin: 0 0 !important;
     transition: 0.2s;
-    width: 7rem;
-}
+    width: 70%;
+}  
 
 .powercord-spotify:hover>.container-YkUktl>.nameTag-sc-gpq {
-    top: 87% !important;
+    top: 4px !important;
 }
 
 .spotify-artist {
@@ -3362,6 +3384,22 @@ body.foldercontentopened .base-2jDfDU {
     height: 25px;
     width: 7rem;
 }
+
+.spotify-extra-controls,
+.powercord-spotify:hover .spotify-extra-controls {
+  position: absolute;
+  top: 62px !important;
+  left: 70px !important;
+  margin: 0 0 !important;
+  transition: 0.2s;
+  width: 100%;
+  height: 0 !important;
+  opacity: 1 !important;
+}
+.spotify-seek {
+  display: none !important;
+}
+
 
 .powercord-snippet-apply:not(.applied) div:hover {
     border-radius: 4px;

--- a/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
+++ b/BetterDiscordAddons/Themes/modernx-discord.theme.source.css
@@ -3331,29 +3331,26 @@ body.foldercontentopened .base-2jDfDU {
     border-right: 1px solid var(--spotify-color);
     overflow: hidden;
 }
+.powercord-spotify:hover {
+  left: 0px;
+  height: 150px;
+}
 .wrapper-3Hk9OB:empty ~ .powercord-spotify:hover {
   height: 80px;
 }
-
 .wrapper-3Hk9OB:hover ~ .powercord-spotify{
   left: 0px;
   height: 150px;
 }
-
 .wrapper-3Hk9OB:after:hover ~ .powercord-spotify{
   left: 0px;
   height: 150px;
 }
-
 .avatarWrapper-1B9FTW:hover ~ .powercord-spotify{
   left: 0px;
   height: 150px;
 }
 
-.powercord-spotify:hover {
-  left: 0px;
-  height: 150px;
-}
 .panels-3wFtMD .wrapper-3Hk9OB .container-1zzFcN:after, .panels-3wFtMD .wrapper-3Hk9OB~.container-YkUktl .directionRow-2Iu2A9:after {
   width: 242px
 }


### PR DESCRIPTION
As was talked about, this resolves #20, I've worked on a solution to the Spotify issue, and have done so in a way that fits the design language of the theme fairly well.
This PR is a refined version of the concept in the issue, even if not much has changed, to actually replace the setup in the source CSS file to ensure there's no values overwriting or messing with one another.

If there were to be any improvements made to this PR it would be:
Try to cut down on `!important` uses, I was more just being lazy and left those as is 'just in case'
There's also a rudementary solution to the call menu preventing access to the spotify modal with this PR, but it's both a very rough solution, and could probably be done better (Raising the spotify modal to be above the call menu and be a horizontal side menu instead of a corner menu? Putting it at the bottom of the member list? Dunno)

All in all though, this at works fairly well, and should serve as a suitable fix to the issue.